### PR TITLE
Add modified `ipynb_to_gallery` script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,8 @@ For most cases environments should be documented using a docstring inside the en
 
 We use Sphinx-Gallery to build the tutorials inside the docs/tutorials directory.
 
-To convert Jupyter Notebooks to Python tutorials you can use [this script](https://gist.github.com/mgoulao/f07f5f79f6cd9a721db8a34bba0a19a7).
+To convert Jupyter Notebooks to Python tutorials you can use [this script](./starter_kit/_scripts/ipynb_to_gallery.py).
+To convert cells outputting static images, like `<img src="../_static/img/tutorials/my_image.png" alt="My image description">`, they need to be in single Mardown cell and have an `alt` text.
 
 If you want Sphinx-Gallery to execute the tutorial (which adds outputs and plots) then the file name should start with run_. Note that this adds to the build time so make sure the script doesn't take more than a few seconds to execute.
 

--- a/starter_kit/_scripts/ipynb_to_gallery.py
+++ b/starter_kit/_scripts/ipynb_to_gallery.py
@@ -1,0 +1,62 @@
+"""Convert jupyter notebook to sphinx gallery notebook styled examples.
+
+Usage: python ipynb_to_gallery.py <notebook.ipynb>
+
+Dependencies: pypandoc, beautifulsoup4, numpy
+install using `pip install pypandoc, beautifulsoup4, numpy`
+"""
+import json
+import warnings
+
+import numpy as np
+import pypandoc as pdoc
+from bs4 import BeautifulSoup
+
+warnings.filterwarnings(
+    "ignore",
+    message="The input looks more like a filename than markup. You may want to open this file and pass the filehandle into Beautiful Soup",
+)
+
+
+def convert_ipynb_to_gallery(file_name):
+    python_file = ""
+
+    nb_dict = json.load(open(file_name))
+    cells = nb_dict["cells"]
+
+    for i, cell in enumerate(cells):
+        if i == 0:
+            assert cell["cell_type"] == "markdown", "First cell has to be markdown"
+
+            md_source = "".join(cell["source"])
+            rst_source = pdoc.convert_text(md_source, "rst", "md")
+            python_file = '"""\n' + rst_source + '\n"""'
+        else:
+            if cell["cell_type"] == "markdown":
+                md_source = "".join(cell["source"])
+                is_all_lines_html = np.all(
+                    [
+                        bool(BeautifulSoup(line, "html.parser").find())
+                        for line in cell["source"]
+                    ]
+                )
+                if is_all_lines_html:
+                    rst_source = pdoc.convert_text(
+                        source=md_source, to="rst", format="html"
+                    )
+                else:
+                    rst_source = pdoc.convert_text(md_source, "rst", "md")
+                commented_source = "\n".join(["# " + x for x in rst_source.split("\n")])
+                python_file = python_file + "\n\n\n" + "# %%" + "\n" + commented_source
+            elif cell["cell_type"] == "code":
+                source = "".join(cell["source"])
+                python_file = python_file + "\n" * 2 + source
+
+    python_file = python_file.replace("\n%", "\n# %")
+    open(file_name.replace(".ipynb", ".py"), "w").write(python_file)
+
+
+if __name__ == "__main__":
+    import sys
+
+    convert_ipynb_to_gallery(sys.argv[-1])


### PR DESCRIPTION
As discussed on Discord, this PR adds a modified version of [the `ipynb_to_gallery` script](https://gist.github.com/mgoulao/f07f5f79f6cd9a721db8a34bba0a19a7). Its main improvement is that it supports converting static images like `<img src="../_static/img/tutorials/my_image.png" alt="My image description">` in Markdown cells in the original Jupyter notebook, which gets converted as RST comments in the output Python file.