### PR TITLE
Document just serve workflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,14 +454,27 @@ sphinx_gallery_conf = {
 
 ## Building Theme from source
 
-To contribute to the theme you will need to build it. The toolchain (Python, Node, uv) is pinned in `mise.toml`; install [mise](https://mise.jdx.dev/) and run `mise install` from the repo root to provision matching versions. Then run `nox` via `uvx`:
+To contribute to the theme you will need to build it. The toolchain (Python, Node, `uv`, `just`) is pinned in `mise.toml`; install [mise](https://mise.jdx.dev/) and run `mise install` from the repo root to provision matching versions.
 
 ```
 mise install
-uvx nox -s docs-live
+just serve
 ```
 
-Nox uses `uv` as its venv backend (configured in `noxfile.py`), so session installs are fast. Available sessions: `docs`, `docs-live`, `lint`, `test`, `release`.
+`just serve` runs the live-reload docs server bound to `0.0.0.0:8000` so the site is reachable from another device on your LAN (e.g. a phone). To use a different host or port:
+
+```
+just serve 127.0.0.1 9000
+```
+
+Other recipes in the `Justfile`:
+
+- `just build` — build the docs into `build/docs` once (no live-reload).
+- `just lint` — run the pre-commit linters (ruff, prettier, mypy, …).
+
+Each recipe is a thin wrapper around `uvx nox -s <session>`. Nox uses `uv` as its venv backend (configured in `noxfile.py`), so session installs are fast. Available sessions: `docs`, `docs-live`, `lint`, `release`.
+
+For a fuller walkthrough of the contributor workflow — initial setup, linting, the dev server, the release process — see `docs/contributing/workflow.md` (or run `just serve` and browse to it).
 
 
 ## License


### PR DESCRIPTION
## Summary

Update the **Building Theme from source** section of `README.md` to describe the contributor workflow that landed in #5 — `just`, the LAN-friendly dev server, and the new docs page.

- Replace the bare `uvx nox -s docs-live` invocation with `just serve` (a thin wrapper that binds to `0.0.0.0:8000` so the live-reload site is reachable from another device on your LAN — useful for previewing on a phone).
- Document overriding the host/port via `just serve <host> <port>` for when the LAN default isn't wanted.
- List the other `Justfile` recipes (`just build`, `just lint`) and their pre-commit linter set (ruff, prettier, mypy, …).
- Drop `test` from the list of available nox sessions to match the post-#5 state of `noxfile.py`.
- Point readers at `docs/contributing/workflow.md` for the longer walkthrough (initial setup, linting, dev server, release process). The `just serve` tip there is intentional — once the server is up, the contributor docs are one click away.

The README's other sections (Install, Build Documentation for downstream projects, Theme Options, Custom Directives, Frontmatter, Tutorials) are untouched in this PR — they're candidates for a future migration into the served Sphinx docs but out of scope here.

## Test plan

- [ ] Read the new "Building Theme from source" section on the rendered README — copy/paste of `mise install` and `just serve` brings the docs up at `http://<lan-ip>:8000`.
- [ ] `just serve 127.0.0.1 9000` overrides host and port as advertised.
- [ ] `just build` produces `build/docs/`; `just lint` runs the pre-commit suite.
- [ ] `uvx nox --list-sessions` shows `docs`, `docs-live`, `lint`, `release` (no `test`), matching the README's sessions list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
